### PR TITLE
Support running the app from any directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,10 @@ var IoC = require('electrolyte')
 var bootable = require('bootable')
 var express = require('express')
 
+// change the working directory to the root directory
+
+process.chdir(__dirname)
+
 // dependency injection
 
 IoC.loader(IoC.node(path.join(__dirname, 'boot')))


### PR DESCRIPTION
At this moment if you run the `app.js` from other directory you get this error:

```
error: Cannot call method 'listen' of undefined
error: TypeError: Cannot call method 'listen' of undefined
    at Function.<anonymous> (/Users/gimenete/projects/eskimo/node_modules/igloo/lib/boot/server.js:50:19)
    at next (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/initializer.js:43:15)
    at next (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/initializer.js:46:9)
    at next (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/initializer.js:46:9)
    at Function.initializers (/Users/gimenete/projects/eskimo/node_modules/bootable/node_modules/bootable-di/lib/phases/initializers.js:53:36)
    at next (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/initializer.js:43:15)
    at Initializer.run (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/initializer.js:52:3)
    at Function.app.boot (/Users/gimenete/projects/eskimo/node_modules/bootable/lib/index.js:42:23)
    at Object.<anonymous> (/Users/gimenete/projects/eskimo/app.js:38:5)
    at Module._compile (module.js:456:26)
```

It seems that `bootable` does not find the files inside `etc/init`.

Changing the working directory in the beginning solves the problem.
